### PR TITLE
Add ability to use multiple glob patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+components

--- a/Readme.md
+++ b/Readme.md
@@ -23,16 +23,16 @@ var less = require('gulp-less');
 // plugins
 duo.use(gulp('*.coffee', coffee)());
 duo.use(gulp('*.less', less)());
-duo.use(gulp('*.css', uncss)(opts));
+duo.use(gulp(['*.css', 'vendor/*.css'], uncss)(opts));
 
 duo.run(fn);
 ```
 
 ## API
 
-### gulp([glob], plugin)([opts])
+### gulp([patterns], plugin)([opts])
 
-Wrap the gulp `plugin`. Optionally filter plugins using `glob`.
+Wrap the gulp `plugin`. Optionally filter plugins using `patterns`.
 
 The function returns another function that you can use to pass options to the gulp plugin.
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var minimatch = require('minimatch');
+var multimatch = require('multimatch');
 var filepipe = require('file-pipe');
 var extname = require('path').extname;
 var slice = [].slice;
@@ -32,7 +32,7 @@ function Gulp(glob, fn) {
 
     // duo plugin function
     return function gulp(file, entry, done) {
-      if (glob && !minimatch(file.id, glob)) return done();
+      if (glob && !multimatch(file.id, glob).length) return done();
       var instance = fn.apply(fn, args);
 
       // initialize the file-pipe

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "file-pipe": "0.0.3",
-    "minimatch": "~1.0.0"
+    "multimatch": "^0.3.0"
   },
   "devDependencies": {
     "mocha": "*",
     "duo": "~0.7.1",
-    "co-mocha": "0.0.4",
+    "co-mocha": "1.0.0",
     "gnode": "0.0.8",
     "gulp-coffee": "~2.1.1",
     "gulp-less": "~1.3.3",

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -61,7 +61,7 @@ describe('duo-gulp', function() {
   describe('gulp(glob, plugin)', function() {
     it('should filter plugins based on `glob`', function *() {
       var duo = create('less', 'index.less');
-      duo.use(gulp('*.coffee', coffee)());
+      duo.use(gulp(['*', '!*.less'], coffee)());
       duo.use(gulp('*.less', less)());
       var css = yield duo.run();
       assert(css == read('less/build.css'));


### PR DESCRIPTION
gulp accepts multiple glob patterns, such as:

``` js
gulp.src(['*src/*.css', 'vendor/*.css'])
```

This feature is very useful, but this plugin doesn't have that, currently.

So I introduced [multimatch](https://github.com/sindresorhus/multimatch) to accept multiple glob patterns.
After merging this PR, we can use this plugin as below:

``` js
var gulp = require('duo-gulp');
var duo = Duo(root).entry(entry);
var uncss = require('gulp-uncss');

duo.use(gulp(['src/*.css', 'vendor/*.css'], uncss)());
```
